### PR TITLE
ValueError: too many values to unpack

### DIFF
--- a/programas/cap14/ex05.py
+++ b/programas/cap14/ex05.py
@@ -12,7 +12,7 @@ while True:
 
   elementoEstruturante = np.ones((10, 10), np.uint8)
   frameSegmentado = cv2.morphologyEx(frameSegmentado, cv2.MORPH_CLOSE, elementoEstruturante)
-  contornos, hierarquia = cv2.findContours(frameSegmentado, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
+  _,contornos, hierarquia = cv2.findContours(frameSegmentado, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
 
   if len(contornos) >= 1:
     objeto = contornos[0]


### PR DESCRIPTION
Esse erro aparece para a última versão do OpenCV em quaisquer versões do Python (2.7 ou 3.x) e basta colocar o underline que o erro é corrigido.